### PR TITLE
Update phpab.php

### DIFF
--- a/phpab.php
+++ b/phpab.php
@@ -242,8 +242,12 @@ class phpab
 		}
 		unset($tmp);
 		
-		$this->content = str_replace('</body>', '<!--A/B tests active with phpA/B ' . $this->version . '--></body>', $this->content);
-		
+		$pos = strrpos($this->content, '</body>');
+		if($pos !== false)
+		{
+			$this->content = substr_replace($this->content, '<!--A/B tests active with phpA/B ' . $this->version . '--></body>', $pos, strlen('</body>'));
+		}
+
 		$this->content = str_replace('{' . $this->tag . ' ' . $this->test_name . ' current_varation}', $this->current_variation, $this->content);
 		
 		if($this->trial_mode != TRUE)


### PR DESCRIPTION
Minor change to ensure that the </body> with the A/B tests version info and comment is the last </body> on the page.

Running this code on a page with </body> in comment tags (due to DoubleClick Floodlight tag comments) would cause problems.
