### PR TITLE
Add DuckDuckGo to the bot list

### DIFF
--- a/phpab.php
+++ b/phpab.php
@@ -29,7 +29,7 @@ class phpab
 	{
 		if($this->detect_bots == TRUE)
 		{
-			$bots = array('googlebot', 'msnbot', 'slurp', 'ask jeeves', 'crawl', 'ia_archiver', 'lycos');
+			$bots = array('googlebot', 'msnbot', 'slurp', 'ask jeeves', 'crawl', 'ia_archiver', 'lycos', 'duckduckbot');
 			foreach($bots as $botname)
 			{
 				if(stripos($_SERVER['HTTP_USER_AGENT'], $botname) !== FALSE)


### PR DESCRIPTION
Per [this page](http://www.user-agents.org/cgi-bin/free-search.cgi?template=free-search-detail.html&dbname=allagents.csv&key2=id_a_f_290308_2&action=searchdbdisplay), the DuckDuckGo user agent is `DuckDuckBot/1.0;`
