### PR TITLE
When test_domain contains port, setcookie will fail

### DIFF
--- a/phpab.php
+++ b/phpab.php
@@ -127,7 +127,8 @@ class phpab
 	
 	private function record_user_segment ()
 	{
-		setcookie($this->tag . '-' . $this->test_name, $this->current_variation, time() + (60 * 60 * 24 * 365), '/', $this->test_domain);
+		$cookie_domain = (($colon_position = strrpos($this->test_domain, ":")) === false) ? $this->test_domain : substr($this->test_domain, 0, $colon_position);
+        	setcookie($this->tag . '-' . $this->test_name, $this->current_variation, time() + (60 * 60 * 24 * 365), '/', $cookie_domain);
 	}
 	
 	public function set_domain ($d)


### PR DESCRIPTION
When test_domain contains port, setcookie will fail because of cookie can't be set under a domain with port. So, in this pull request, I remove port from test domain when calling setcookie

referrer: http://stackoverflow.com/questions/1612177/are-http-cookies-port-specific